### PR TITLE
Change default bin path `lime-bin` -> `./lime-bin`

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "bin,b",
-			Value: "lime-bin",
+			Value: "./lime-bin",
 			Usage: "path of generated binary file",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
Currently, default bin-path is `lime-bin`. However, this bin-path is not called actually.
To fix this problem, I changed the default bin-path to `./lime-bin`.
